### PR TITLE
Implement CSV meter reading upload

### DIFF
--- a/MeterReadingsApi/MeterReadingsApi.DataModel/Account.cs
+++ b/MeterReadingsApi/MeterReadingsApi.DataModel/Account.cs
@@ -4,8 +4,8 @@
     {
         public Guid Id { get; set; }
         public int AccountId { get; set; }
-        public string FirstName { get; set; }
-        public string LastName { get; set; }
-        public List<MeterReading> MeterReadings { get; set; }
+        public string FirstName { get; set; } = string.Empty;
+        public string LastName { get; set; } = string.Empty;
+        public List<MeterReading> MeterReadings { get; set; } = new();
     }
 }

--- a/MeterReadingsApi/MeterReadingsApi.DataModel/MeterReading.cs
+++ b/MeterReadingsApi/MeterReadingsApi.DataModel/MeterReading.cs
@@ -7,6 +7,6 @@
         public DateTime MeterReadingDateTime { get; set; }
         public int MeterReadValue { get; set; }
 
-        public Account Account { get; set; }
+        public Account Account { get; set; } = default!;
     }
 }

--- a/MeterReadingsApi/MeterReadingsApi.DataModel/MeterReadingsApi.DataModel.csproj
+++ b/MeterReadingsApi/MeterReadingsApi.DataModel/MeterReadingsApi.DataModel.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0-preview.5.24306.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.7" />
   </ItemGroup>
 
 </Project>

--- a/MeterReadingsApi/MeterReadingsApi/Controllers/MeterReadingsController.cs
+++ b/MeterReadingsApi/MeterReadingsApi/Controllers/MeterReadingsController.cs
@@ -3,7 +3,9 @@
     using MeterReadingsApi.Interfaces;
     using MeterReadingsApi.DataModel;
     using MeterReadingsApi.Repositories;
+    using MeterReadingsApi.Models;
     using System.Collections.Generic;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Configuration;
 
@@ -46,9 +48,73 @@
 
         [Route("meter-reading-uploads")]
         [HttpPost]
-        public ActionResult MeterReadingUploads()
+        public async Task<ActionResult> MeterReadingUploads(IFormFile? file)
         {
-            return Ok();
+            if (file == null || file.Length == 0)
+            {
+                return BadRequest();
+            }
+
+            IEnumerable<MeterReadingCsvRecord> records;
+            try
+            {
+                using var stream = file.OpenReadStream();
+                records = await csvService.ReadMeterReadingsAsync(stream);
+            }
+            catch
+            {
+                return BadRequest();
+            }
+
+            var validReadings = new List<MeterReading>();
+            int success = 0;
+            int failed = 0;
+
+            foreach (var record in records)
+            {
+                if (!repository.AccountExists(record.AccountId))
+                {
+                    failed++;
+                    continue;
+                }
+
+                if (!int.TryParse(record.MeterReadValue, out var value) || value < 0 || value > 99999)
+                {
+                    failed++;
+                    continue;
+                }
+
+                if (repository.ReadingExists(record.AccountId, record.MeterReadingDateTime))
+                {
+                    failed++;
+                    continue;
+                }
+
+                validReadings.Add(new MeterReading
+                {
+                    AccountId = record.AccountId,
+                    MeterReadingDateTime = record.MeterReadingDateTime,
+                    MeterReadValue = value
+                });
+                success++;
+            }
+
+            if (validReadings.Count > 0)
+            {
+                await repository.AddMeterReadingsAsync(validReadings);
+            }
+
+            if (success == 0)
+            {
+                return UnprocessableEntity(new { successful = success, failed });
+            }
+
+            if (failed > 0)
+            {
+                return StatusCode(StatusCodes.Status207MultiStatus, new { successful = success, failed });
+            }
+
+            return StatusCode(StatusCodes.Status201Created, new { successful = success, failed });
         }
     }
 }

--- a/MeterReadingsApi/MeterReadingsApi/Interfaces/ICSVService.cs
+++ b/MeterReadingsApi/MeterReadingsApi/Interfaces/ICSVService.cs
@@ -1,6 +1,9 @@
-﻿namespace MeterReadingsApi.Interfaces
+using MeterReadingsApi.Models;
+
+namespace MeterReadingsApi.Interfaces
 {
     public interface ICSVService
     {
+        Task<IEnumerable<MeterReadingCsvRecord>> ReadMeterReadingsAsync(Stream stream);
     }
 }

--- a/MeterReadingsApi/MeterReadingsApi/Models/MeterReadingCsvMap.cs
+++ b/MeterReadingsApi/MeterReadingsApi/Models/MeterReadingCsvMap.cs
@@ -1,0 +1,14 @@
+using CsvHelper.Configuration;
+
+namespace MeterReadingsApi.Models
+{
+    public sealed class MeterReadingCsvMap : ClassMap<MeterReadingCsvRecord>
+    {
+        public MeterReadingCsvMap()
+        {
+            Map(m => m.AccountId).Name("AccountId");
+            Map(m => m.MeterReadingDateTime).Name("MeterReadingDateTime").TypeConverterOption.Format("dd/MM/yyyy HH:mm");
+            Map(m => m.MeterReadValue).Name("MeterReadValue");
+        }
+    }
+}

--- a/MeterReadingsApi/MeterReadingsApi/Models/MeterReadingCsvRecord.cs
+++ b/MeterReadingsApi/MeterReadingsApi/Models/MeterReadingCsvRecord.cs
@@ -1,0 +1,9 @@
+namespace MeterReadingsApi.Models
+{
+    public class MeterReadingCsvRecord
+    {
+        public int AccountId { get; set; }
+        public DateTime MeterReadingDateTime { get; set; }
+        public string MeterReadValue { get; set; } = string.Empty;
+    }
+}

--- a/MeterReadingsApi/MeterReadingsApi/Repositories/IMeterReadingsRepository.cs
+++ b/MeterReadingsApi/MeterReadingsApi/Repositories/IMeterReadingsRepository.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using MeterReadingsApi.DataModel;
 
 namespace MeterReadingsApi.Repositories
@@ -6,6 +5,9 @@ namespace MeterReadingsApi.Repositories
     public interface IMeterReadingsRepository
     {
         IEnumerable<Account> GetAccounts();
+        Task AddMeterReadingsAsync(IEnumerable<MeterReading> readings);
+        bool AccountExists(int accountId);
+        bool ReadingExists(int accountId, DateTime dateTime);
         void EnsureSeedData();
     }
 }

--- a/MeterReadingsApi/MeterReadingsApi/Repositories/MeterReadingsRepository.cs
+++ b/MeterReadingsApi/MeterReadingsApi/Repositories/MeterReadingsRepository.cs
@@ -17,6 +17,22 @@ namespace MeterReadingsApi.Repositories
             return context.Accounts.AsNoTracking().ToList();
         }
 
+        public bool AccountExists(int accountId)
+        {
+            return context.Accounts.Any(a => a.AccountId == accountId);
+        }
+
+        public bool ReadingExists(int accountId, DateTime dateTime)
+        {
+            return context.MeterReadings.Any(r => r.AccountId == accountId && r.MeterReadingDateTime == dateTime);
+        }
+
+        public async Task AddMeterReadingsAsync(IEnumerable<MeterReading> readings)
+        {
+            await context.MeterReadings.AddRangeAsync(readings);
+            await context.SaveChangesAsync();
+        }
+
         public void EnsureSeedData()
         {
             context.Database.EnsureCreated();

--- a/MeterReadingsApi/MeterReadingsApi/Services/CsvService.cs
+++ b/MeterReadingsApi/MeterReadingsApi/Services/CsvService.cs
@@ -1,24 +1,24 @@
-﻿using System.Text;
+using CsvHelper;
+using MeterReadingsApi.Interfaces;
+using MeterReadingsApi.Models;
+using System.Globalization;
+using System.Text;
 
 namespace MeterReadingsApi.Services
 {
-    using CsvHelper;
-    using MeterReadingsApi.Interfaces;
-    using System.Globalization;
-    using System.IO;
-    using System.Linq;
-
-    public class CsvService: ICSVService
+    public class CsvService : ICSVService
     {
-        public IEnumerable<string> ReadCsvFileForMeterReadings(string location)
+        public async Task<IEnumerable<MeterReadingCsvRecord>> ReadMeterReadingsAsync(Stream stream)
         {
-                //using var reader = new StreamReader(location, Encoding.Default);
-                //using var csv = new CsvReader(reader, CultureInfo.InvariantCulture);
-                //csv.Context.RegisterClassMap<MeterReadingsMap>();
-                //var records = csv.GetRecords<MeterReadingModel>();
-                //return records.ToList();
-
-            return new List<string>();
+            using var reader = new StreamReader(stream, Encoding.UTF8, leaveOpen: true);
+            using var csv = new CsvReader(reader, CultureInfo.InvariantCulture);
+            csv.Context.RegisterClassMap<MeterReadingCsvMap>();
+            var records = new List<MeterReadingCsvRecord>();
+            await foreach (var record in csv.GetRecordsAsync<MeterReadingCsvRecord>())
+            {
+                records.Add(record);
+            }
+            return records;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add CSV record model and map
- implement CsvService parsing logic
- extend repository for meter reading storage and validation helpers
- parse uploaded CSV in controller and return correct status codes
- update EF Core version and fix nullable warnings

## Testing
- `dotnet build MeterReadingsApi/MeterReadingsApi.sln -warnaserror`
- `dotnet test MeterReadingsApi/MeterReadingsApi.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_688d07828a98833286a37b2ac291973e