### PR TITLE
Use dedicated result type for UploadAsync

### DIFF
--- a/MeterReadingsApi/MeterReadingsApi/Controllers/MeterReadingsController.cs
+++ b/MeterReadingsApi/MeterReadingsApi/Controllers/MeterReadingsController.cs
@@ -3,6 +3,7 @@
     using MeterReadingsApi.DataModel;
     using MeterReadingsApi.Interfaces;
     using MeterReadingsApi.Repositories;
+    using MeterReadingsApi.Models;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Configuration;
@@ -47,7 +48,7 @@
 
         [Route("meter-reading-uploads")]
         [HttpPost]
-        public async Task<ActionResult> MeterReadingUploads(IFormFile? file)
+        public async Task<ActionResult> MeterReadingUploads([FromForm] IFormFile? file)
         {
             if (file == null || file.Length == 0)
             {
@@ -56,16 +57,16 @@
 
             try
             {
-                var (success, failed) = await uploadService.UploadAsync(file);
+                var result = await uploadService.UploadAsync(file);
 
-                if (success == 0)
+                if (result.Successful == 0)
                 {
-                    return UnprocessableEntity(new { successful = success, failed });
+                    return UnprocessableEntity(new { successful = result.Successful, failed = result.Failed });
                 }
 
-                if (failed > 0)
+                if (result.Failed > 0)
                 {
-                    return StatusCode(StatusCodes.Status207MultiStatus, new { successful = success, failed });
+                    return StatusCode(StatusCodes.Status207MultiStatus, new { successful = result.Successful, failed = result.Failed });
                 }
 
                 return StatusCode(StatusCodes.Status201Created);

--- a/MeterReadingsApi/MeterReadingsApi/Interfaces/IMeterReadingUploadService.cs
+++ b/MeterReadingsApi/MeterReadingsApi/Interfaces/IMeterReadingUploadService.cs
@@ -4,6 +4,6 @@ namespace MeterReadingsApi.Interfaces
 {
     public interface IMeterReadingUploadService
     {
-        Task<(int Successful, int Failed)> UploadAsync(IFormFile file);
+        Task<Models.MeterReadingUploadResult> UploadAsync(IFormFile file);
     }
 }

--- a/MeterReadingsApi/MeterReadingsApi/Models/MeterReadingUploadResult.cs
+++ b/MeterReadingsApi/MeterReadingsApi/Models/MeterReadingUploadResult.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace MeterReadingsApi.Models
+{
+    [Serializable]
+    public readonly record struct MeterReadingUploadResult(
+        [property: JsonPropertyName("successful")] int Successful,
+        [property: JsonPropertyName("failed")] int Failed);
+}

--- a/MeterReadingsApi/MeterReadingsApi/Services/MeterReadingUploadService.cs
+++ b/MeterReadingsApi/MeterReadingsApi/Services/MeterReadingUploadService.cs
@@ -19,7 +19,7 @@ namespace MeterReadingsApi.Services
             this.validator = validator;
         }
 
-        public async Task<(int Successful, int Failed)> UploadAsync(IFormFile file)
+        public async Task<Models.MeterReadingUploadResult> UploadAsync(IFormFile file)
         {
             using var stream = file.OpenReadStream();
             var records = await csvService.ReadMeterReadingsAsync(stream);
@@ -53,7 +53,7 @@ namespace MeterReadingsApi.Services
                 await repository.AddMeterReadingsAsync(validReadings);
             }
 
-            return (success, failed);
+            return new Models.MeterReadingUploadResult(success, failed);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `MeterReadingUploadResult` type for service return value
- refactor upload service, controller, and interface to use the new result type
- annotate result type properties for serialization and bind upload file from form

## Testing
- `dotnet build MeterReadingsApi/MeterReadingsApi.sln --no-restore`
- `dotnet test MeterReadingsApi/MeterReadingsApi.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_688d15bb8198833299c233e43009c96d