### PR TITLE
Add namespaces to unit tests

### DIFF
--- a/MeterReadingsApi/MeterReadingsApi.UnitTests/MeterReadingCsvRecordValidatorTests.cs
+++ b/MeterReadingsApi/MeterReadingsApi.UnitTests/MeterReadingCsvRecordValidatorTests.cs
@@ -7,8 +7,8 @@ using MeterReadingsApi.Repositories;
 using MeterReadingsApi.Validators;
 using Xunit;
 
-namespace MeterReadingsApi.UnitTests;
-
+namespace MeterReadingsApi.UnitTests
+{
 public class MeterReadingCsvRecordValidatorTests
 {
     private class FakeRepository : IMeterReadingsRepository
@@ -104,4 +104,5 @@ public class MeterReadingCsvRecordValidatorTests
         var result = validator.Validate(record);
         Assert.False(result.IsValid);
     }
+}
 }

--- a/MeterReadingsApi/MeterReadingsApi.UnitTests/MeterReadingsControllerTests.cs
+++ b/MeterReadingsApi/MeterReadingsApi.UnitTests/MeterReadingsControllerTests.cs
@@ -2,8 +2,8 @@
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
-namespace MeterReadingsApi.UnitTests;
-
+namespace MeterReadingsApi.UnitTests
+{
 public class MeterReadingsControllerTests
 {
     //[Fact]
@@ -28,4 +28,4 @@ public class MeterReadingsControllerTests
 
     //    Assert.All(result, forecast => Assert.False(string.IsNullOrWhiteSpace(forecast.Summary)));
     //}
-}
+}}


### PR DESCRIPTION
## Summary
- add block-scoped namespaces for test classes

## Testing
- `dotnet test MeterReadingsApi/MeterReadingsApi.sln -c Release -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_688d344652a483329046e386a15b62ed