### PR TITLE
Add Arrange/Act/Assert comments to tests

### DIFF
--- a/MeterReadingsApi/MeterReadingsApi.IntegrationTests/CsvServiceTests.cs
+++ b/MeterReadingsApi/MeterReadingsApi.IntegrationTests/CsvServiceTests.cs
@@ -12,6 +12,7 @@ namespace MeterReadingsApi.UnitTests
         [Fact]
         public async Task ReadMeterReadingsAsync_ParsesRecordsCorrectly()
         {
+            // Arrange
             string csv = "AccountId,MeterReadingDateTime,MeterReadValue\n" +
                       "1234,16/05/2019 09:24,00123\n" +
                       "5678,17/05/2019 12:00,00456\n";
@@ -19,9 +20,11 @@ namespace MeterReadingsApi.UnitTests
             await using MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes(csv));
             CsvService service = new CsvService();
 
+            // Act
             IEnumerable<MeterReadingCsvRecord> result = await service.ReadMeterReadingsAsync(stream);
             List<MeterReadingCsvRecord> list = result.ToList();
 
+            // Assert
             Assert.Equal(2, list.Count);
             Assert.Equal(1234, list[0].AccountId);
             Assert.Equal(new System.DateTime(2019, 5, 16, 9, 24, 0), list[0].MeterReadingDateTime);

--- a/MeterReadingsApi/MeterReadingsApi.IntegrationTests/MeterReadingsControllerIntegrationTests.cs
+++ b/MeterReadingsApi/MeterReadingsApi.IntegrationTests/MeterReadingsControllerIntegrationTests.cs
@@ -31,17 +31,21 @@ public class MeterReadingsControllerIntegrationTests : IClassFixture<TestApiFact
     [Fact]
     public async Task Upload_ValidFile_ReturnsCreated()
     {
+        // Arrange
         string csv = "AccountId,MeterReadingDateTime,MeterReadValue\n" +
                   "2344,16/05/2019 09:24,00123\n" +
                   "2233,17/05/2019 12:00,00456\n";
 
         using HttpContent content = CreateCsvContent(csv);
-        HttpResponseMessage response = await client.PostAsync("/api/meter-readings/meter-reading-uploads", content);
-        response.EnsureSuccessStatusCode();
-        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
+        // Act
+        HttpResponseMessage response = await client.PostAsync("/api/meter-readings/meter-reading-uploads", content);
         string body = await response.Content.ReadAsStringAsync();
         MeterReadingUploadResult result = JsonSerializer.Deserialize<MeterReadingUploadResult>(body)!;
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         Assert.Equal(2, result.Successful);
         Assert.Equal(0, result.Failed);
     }
@@ -50,15 +54,19 @@ public class MeterReadingsControllerIntegrationTests : IClassFixture<TestApiFact
     [Fact]
     public async Task Upload_InvalidFile_ReturnsUnprocessable()
     {
+        // Arrange
         string csv = "AccountId,MeterReadingDateTime,MeterReadValue\n" +
                   "9999,16/05/2019 09:24,ABCDE\n";
 
         using HttpContent content = CreateCsvContent(csv);
-        HttpResponseMessage response = await client.PostAsync("/api/meter-readings/meter-reading-uploads", content);
-        Assert.Equal((HttpStatusCode)422, response.StatusCode);
 
+        // Act
+        HttpResponseMessage response = await client.PostAsync("/api/meter-readings/meter-reading-uploads", content);
         string body = await response.Content.ReadAsStringAsync();
         MeterReadingUploadResult result = JsonSerializer.Deserialize<MeterReadingUploadResult>(body)!;
+
+        // Assert
+        Assert.Equal((HttpStatusCode)422, response.StatusCode);
         Assert.Equal(0, result.Successful);
         Assert.Equal(1, result.Failed);
     }

--- a/MeterReadingsApi/MeterReadingsApi.IntegrationTests/MeterReadingsRepositoryTests.cs
+++ b/MeterReadingsApi/MeterReadingsApi.IntegrationTests/MeterReadingsRepositoryTests.cs
@@ -21,6 +21,7 @@ namespace MeterReadingsApi.UnitTests
         [Fact]
         public async Task AddMeterReadingsAsync_PersistsReadings()
         {
+            // Arrange
             MeterReadingsRepository repo = CreateRepository();
             repo.EnsureSeedData();
             MeterReading reading = new MeterReading
@@ -30,14 +31,17 @@ namespace MeterReadingsApi.UnitTests
                 MeterReadValue = 100
             };
 
+            // Act
             await repo.AddMeterReadingsAsync(new[] { reading });
 
+            // Assert
             Assert.True(repo.ReadingExists(reading.AccountId, reading.MeterReadingDateTime));
         }
 
         [Fact]
         public async Task QueryMethods_ReturnExpectedResults()
         {
+            // Arrange
             MeterReadingsRepository repo = CreateRepository();
             repo.EnsureSeedData();
             Account account = repo.GetAccounts().First();
@@ -47,8 +51,11 @@ namespace MeterReadingsApi.UnitTests
                 MeterReadingDateTime = new DateTime(2024,1,1),
                 MeterReadValue = 200
             };
+
+            // Act
             await repo.AddMeterReadingsAsync(new[] { reading });
 
+            // Assert
             Assert.True(repo.AccountExists(account.AccountId));
             Assert.False(repo.AccountExists(999));
             Assert.True(repo.ReadingExists(account.AccountId, reading.MeterReadingDateTime));

--- a/MeterReadingsApi/MeterReadingsApi.UnitTests/MeterReadingCsvRecordValidatorTests.cs
+++ b/MeterReadingsApi/MeterReadingsApi.UnitTests/MeterReadingCsvRecordValidatorTests.cs
@@ -27,6 +27,7 @@ namespace MeterReadingsApi.UnitTests
         [Fact]
         public void Valid_record_passes_validation()
         {
+            // Arrange
             FakeRepository repo = new FakeRepository();
             MeterReadingCsvRecordValidator validator = new MeterReadingCsvRecordValidator(repo);
             MeterReadingCsvRecord record = new MeterReadingCsvRecord
@@ -36,13 +37,17 @@ namespace MeterReadingsApi.UnitTests
                 MeterReadValue = "01234"
             };
 
+            // Act
             ValidationResult result = validator.Validate(record);
+
+            // Assert
             Assert.True(result.IsValid);
         }
 
         [Fact]
         public void Invalid_meter_read_value_fails_validation()
         {
+            // Arrange
             FakeRepository repo = new FakeRepository();
             MeterReadingCsvRecordValidator validator = new MeterReadingCsvRecordValidator(repo);
             MeterReadingCsvRecord record = new MeterReadingCsvRecord
@@ -52,13 +57,17 @@ namespace MeterReadingsApi.UnitTests
                 MeterReadValue = "1234" // only 4 digits
             };
 
+            // Act
             ValidationResult result = validator.Validate(record);
+
+            // Assert
             Assert.False(result.IsValid);
         }
 
         [Fact]
         public void Duplicate_reading_fails_validation()
         {
+            // Arrange
             FakeRepository repo = new FakeRepository { ReadingExistsReturn = true };
             MeterReadingCsvRecordValidator validator = new MeterReadingCsvRecordValidator(repo);
             MeterReadingCsvRecord record = new MeterReadingCsvRecord
@@ -68,13 +77,17 @@ namespace MeterReadingsApi.UnitTests
                 MeterReadValue = "12345"
             };
 
+            // Act
             ValidationResult result = validator.Validate(record);
+
+            // Assert
             Assert.False(result.IsValid);
         }
 
         [Fact]
         public void Older_reading_fails_validation()
         {
+            // Arrange
             FakeRepository repo = new FakeRepository { HasNewerReadingReturn = true };
             MeterReadingCsvRecordValidator validator = new MeterReadingCsvRecordValidator(repo);
             MeterReadingCsvRecord record = new MeterReadingCsvRecord
@@ -84,13 +97,17 @@ namespace MeterReadingsApi.UnitTests
                 MeterReadValue = "12345"
             };
 
+            // Act
             ValidationResult result = validator.Validate(record);
+
+            // Assert
             Assert.False(result.IsValid);
         }
 
         [Fact]
         public void Unknown_account_fails_validation()
         {
+            // Arrange
             FakeRepository repo = new FakeRepository { AccountExistsReturn = false };
             MeterReadingCsvRecordValidator validator = new MeterReadingCsvRecordValidator(repo);
             MeterReadingCsvRecord record = new MeterReadingCsvRecord
@@ -100,7 +117,10 @@ namespace MeterReadingsApi.UnitTests
                 MeterReadValue = "12345"
             };
 
+            // Act
             ValidationResult result = validator.Validate(record);
+
+            // Assert
             Assert.False(result.IsValid);
         }
     }

--- a/MeterReadingsApi/MeterReadingsApi.UnitTests/MeterReadingUploadServiceTests.cs
+++ b/MeterReadingsApi/MeterReadingsApi.UnitTests/MeterReadingUploadServiceTests.cs
@@ -31,7 +31,7 @@ namespace MeterReadingsApi.UnitTests
         [Fact]
         public async Task UploadAsync_Adds_valid_readings_and_returns_counts()
         {
-            // arrange
+            // Arrange
             MeterReadingCsvRecord[] records = new[]
             {
                 new MeterReadingCsvRecord { AccountId = 1, MeterReadingDateTime = DateTime.UtcNow, MeterReadValue = "12345" },
@@ -49,10 +49,10 @@ namespace MeterReadingsApi.UnitTests
 
             Mock<IFormFile> file = CreateFile();
 
-            // act
+            // Act
             MeterReadingUploadResult result = await service.UploadAsync(file.Object);
 
-            // assert
+            // Assert
             repository.Verify(r => r.AddMeterReadingsAsync(It.Is<IEnumerable<MeterReading>>(l => l != null && l.Count() == 2)), Times.Once);
             Assert.Equal(2, result.Successful);
             Assert.Equal(0, result.Failed);
@@ -61,7 +61,7 @@ namespace MeterReadingsApi.UnitTests
         [Fact]
         public async Task UploadAsync_Handles_invalid_records()
         {
-            // arrange
+            // Arrange
             MeterReadingCsvRecord[] records = new[]
             {
                 new MeterReadingCsvRecord { AccountId = 1, MeterReadingDateTime = DateTime.UtcNow, MeterReadValue = "12345" },
@@ -81,10 +81,10 @@ namespace MeterReadingsApi.UnitTests
 
             Mock<IFormFile> file = CreateFile();
 
-            // act
+            // Act
             MeterReadingUploadResult result = await service.UploadAsync(file.Object);
 
-            // assert
+            // Assert
             repository.Verify(r => r.AddMeterReadingsAsync(It.Is<IEnumerable<MeterReading>>(l => l.Count() == 1)), Times.Once);
             Assert.Equal(1, result.Successful);
             Assert.Equal(1, result.Failed);

--- a/MeterReadingsApi/MeterReadingsApi.UnitTests/MeterReadingsControllerTests.cs
+++ b/MeterReadingsApi/MeterReadingsApi.UnitTests/MeterReadingsControllerTests.cs
@@ -20,11 +20,14 @@ namespace MeterReadingsApi.UnitTests
         [Fact]
         public async Task MeterReadingUploads_Returns_BadRequest_When_File_Is_Null()
         {
+            // Arrange
             Mock<IMeterReadingUploadService> service = new Mock<IMeterReadingUploadService>();
             MeterReadingsController controller = new MeterReadingsController(service.Object);
 
+            // Act
             ActionResult result = await controller.MeterReadingUploads(null);
 
+            // Assert
             BadRequestObjectResult badRequest = Assert.IsType<BadRequestObjectResult>(result);
             Assert.Equal("File is null or empty.", badRequest.Value);
             service.Verify(s => s.UploadAsync(It.IsAny<IFormFile>()), Times.Never);
@@ -33,13 +36,16 @@ namespace MeterReadingsApi.UnitTests
         [Fact]
         public async Task MeterReadingUploads_Returns_BadRequest_When_File_Is_Empty()
         {
+            // Arrange
             Mock<IMeterReadingUploadService> service = new Mock<IMeterReadingUploadService>();
             MeterReadingsController controller = new MeterReadingsController(service.Object);
             Mock<IFormFile> file = new Mock<IFormFile>();
             file.Setup(f => f.Length).Returns(0);
 
+            // Act
             ActionResult result = await controller.MeterReadingUploads(file.Object);
 
+            // Assert
             BadRequestObjectResult badRequest = Assert.IsType<BadRequestObjectResult>(result);
             Assert.Equal("File is null or empty.", badRequest.Value);
             service.Verify(s => s.UploadAsync(It.IsAny<IFormFile>()), Times.Never);
@@ -48,6 +54,7 @@ namespace MeterReadingsApi.UnitTests
         [Fact]
         public async Task MeterReadingUploads_Returns_Created_When_All_Successful()
         {
+            // Arrange
             Mock<IMeterReadingUploadService> service = new Mock<IMeterReadingUploadService>();
             MeterReadingUploadResult uploadResult = new MeterReadingUploadResult(1, 0);
             service.Setup(s => s.UploadAsync(It.IsAny<IFormFile>())).ReturnsAsync(uploadResult);
@@ -55,8 +62,10 @@ namespace MeterReadingsApi.UnitTests
             MeterReadingsController controller = new MeterReadingsController(service.Object);
             IFormFile file = CreateFile();
 
+            // Act
             ActionResult result = await controller.MeterReadingUploads(file);
 
+            // Assert
             CreatedResult created = Assert.IsType<CreatedResult>(result);
             Assert.Equal(uploadResult, created.Value);
             service.Verify(s => s.UploadAsync(It.IsAny<IFormFile>()), Times.Once);
@@ -65,6 +74,7 @@ namespace MeterReadingsApi.UnitTests
         [Fact]
         public async Task MeterReadingUploads_Returns_MultiStatus_When_Some_Fail()
         {
+            // Arrange
             Mock<IMeterReadingUploadService> service = new Mock<IMeterReadingUploadService>();
             MeterReadingUploadResult uploadResult = new MeterReadingUploadResult(1, 1);
             service.Setup(s => s.UploadAsync(It.IsAny<IFormFile>())).ReturnsAsync(uploadResult);
@@ -72,8 +82,10 @@ namespace MeterReadingsApi.UnitTests
             MeterReadingsController controller = new MeterReadingsController(service.Object);
             IFormFile file = CreateFile();
 
+            // Act
             ActionResult result = await controller.MeterReadingUploads(file);
 
+            // Assert
             ObjectResult objectResult = Assert.IsType<ObjectResult>(result);
             Assert.Equal(StatusCodes.Status207MultiStatus, objectResult.StatusCode);
             Assert.Equal(uploadResult, objectResult.Value);
@@ -83,6 +95,7 @@ namespace MeterReadingsApi.UnitTests
         [Fact]
         public async Task MeterReadingUploads_Returns_UnprocessableEntity_When_All_Fail()
         {
+            // Arrange
             Mock<IMeterReadingUploadService> service = new Mock<IMeterReadingUploadService>();
             MeterReadingUploadResult uploadResult = new MeterReadingUploadResult(0, 1);
             service.Setup(s => s.UploadAsync(It.IsAny<IFormFile>())).ReturnsAsync(uploadResult);
@@ -90,8 +103,10 @@ namespace MeterReadingsApi.UnitTests
             MeterReadingsController controller = new MeterReadingsController(service.Object);
             IFormFile file = CreateFile();
 
+            // Act
             ActionResult result = await controller.MeterReadingUploads(file);
 
+            // Assert
             UnprocessableEntityObjectResult unprocessable = Assert.IsType<UnprocessableEntityObjectResult>(result);
             Assert.Equal(uploadResult, unprocessable.Value);
             service.Verify(s => s.UploadAsync(It.IsAny<IFormFile>()), Times.Once);
@@ -100,11 +115,14 @@ namespace MeterReadingsApi.UnitTests
         [Fact]
         public void GetByAccountId_Returns_Ok()
         {
+            // Arrange
             Mock<IMeterReadingUploadService> service = new Mock<IMeterReadingUploadService>();
             MeterReadingsController controller = new MeterReadingsController(service.Object);
 
+            // Act
             ActionResult result = controller.GetByAccountId(1);
 
+            // Assert
             Assert.IsType<OkResult>(result);
         }
     }


### PR DESCRIPTION
## Summary
- clarify test intent by adding Arrange/Act/Assert comments across unit and integration tests

## Testing
- `dotnet test MeterReadingsApi.sln`

------
https://chatgpt.com/codex/tasks/task_e_688dd546f128833292371f3c80253df8