### PR TITLE
Ignore meter readings for unknown accounts

### DIFF
--- a/MeterReadingsApi/MeterReadingsApi.IntegrationTests/MeterReadingsControllerIntegrationTests.cs
+++ b/MeterReadingsApi/MeterReadingsApi.IntegrationTests/MeterReadingsControllerIntegrationTests.cs
@@ -74,6 +74,27 @@ public class MeterReadingsControllerIntegrationTests : IClassFixture<TestApiFact
     }
 
     [Fact]
+    public async Task Upload_FileWithUnknownAccount_IgnoresReading()
+    {
+        // Arrange
+        string csv = "AccountId,MeterReadingDateTime,MeterReadValue\n" +
+                     "4534,19/05/2019 09:24,00123\n" +
+                     "9999,17/05/2019 12:00,00456\n";
+
+        using HttpContent content = CreateCsvContent(csv);
+
+        // Act
+        HttpResponseMessage response = await client.PostAsync("/api/meter-readings/meter-reading-uploads", content);
+        string body = await response.Content.ReadAsStringAsync();
+        MeterReadingUploadResult result = JsonSerializer.Deserialize<MeterReadingUploadResult>(body)!;
+
+        // Assert
+        Assert.Equal((HttpStatusCode)207, response.StatusCode);
+        Assert.Equal(1, result.Successful);
+        Assert.Equal(1, result.Failed);
+    }
+
+    [Fact]
     public async Task GetByAccountId_ReturnsReadings()
     {
         // Arrange - upload a reading first

--- a/MeterReadingsApi/MeterReadingsApi/Validators/MeterReadingCsvRecordValidator.cs
+++ b/MeterReadingsApi/MeterReadingsApi/Validators/MeterReadingCsvRecordValidator.cs
@@ -8,6 +8,8 @@ namespace MeterReadingsApi.Validators
     {
         public MeterReadingCsvRecordValidator(IMeterReadingsRepository repository)
         {
+            RuleLevelCascadeMode = CascadeMode.Stop;
+
             RuleFor(r => r.AccountId)
                 .Must(repository.AccountExists)
                 .WithMessage("Account does not exist");


### PR DESCRIPTION
## Summary
- Stop further validation once account lookup fails
- Verify uploads with a missing account return Multi-Status

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688de4ecc934833288f9a4df3d2278d1