### PR TITLE
Report failed uploads with row numbers

### DIFF
--- a/MeterReadingsApi/MeterReadingsApi.IntegrationTests/MeterReadingsControllerIntegrationTests.cs
+++ b/MeterReadingsApi/MeterReadingsApi.IntegrationTests/MeterReadingsControllerIntegrationTests.cs
@@ -50,6 +50,7 @@ public class MeterReadingsControllerIntegrationTests : IClassFixture<TestApiFact
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         Assert.Equal(2, result.Successful);
         Assert.Equal(0, result.Failed);
+        Assert.Empty(result.Failures);
     }
 
 
@@ -71,6 +72,8 @@ public class MeterReadingsControllerIntegrationTests : IClassFixture<TestApiFact
         Assert.Equal((HttpStatusCode)422, response.StatusCode);
         Assert.Equal(0, result.Successful);
         Assert.Equal(1, result.Failed);
+        MeterReadingUploadFailure failure = Assert.Single(result.Failures);
+        Assert.Equal(2, failure.RowNumber);
     }
 
     [Fact]
@@ -92,6 +95,8 @@ public class MeterReadingsControllerIntegrationTests : IClassFixture<TestApiFact
         Assert.Equal((HttpStatusCode)207, response.StatusCode);
         Assert.Equal(1, result.Successful);
         Assert.Equal(1, result.Failed);
+        MeterReadingUploadFailure failure2 = Assert.Single(result.Failures);
+        Assert.Equal(3, failure2.RowNumber);
     }
 
     [Fact]

--- a/MeterReadingsApi/MeterReadingsApi.UnitTests/MeterReadingUploadServiceTests.cs
+++ b/MeterReadingsApi/MeterReadingsApi.UnitTests/MeterReadingUploadServiceTests.cs
@@ -56,6 +56,7 @@ namespace MeterReadingsApi.UnitTests
             repository.Verify(r => r.AddMeterReadingsAsync(It.Is<IEnumerable<MeterReading>>(l => l != null && l.Count() == 2)), Times.Once);
             Assert.Equal(2, result.Successful);
             Assert.Equal(0, result.Failed);
+            Assert.Empty(result.Failures);
         }
 
         [Fact]
@@ -88,6 +89,9 @@ namespace MeterReadingsApi.UnitTests
             repository.Verify(r => r.AddMeterReadingsAsync(It.Is<IEnumerable<MeterReading>>(l => l.Count() == 1)), Times.Once);
             Assert.Equal(1, result.Successful);
             Assert.Equal(1, result.Failed);
+            MeterReadingUploadFailure failure = Assert.Single(result.Failures);
+            Assert.Equal(3, failure.RowNumber);
+            Assert.Contains("MeterReadValue", failure.Reason);
         }
     }
 }

--- a/MeterReadingsApi/MeterReadingsApi.UnitTests/MeterReadingsControllerTests.cs
+++ b/MeterReadingsApi/MeterReadingsApi.UnitTests/MeterReadingsControllerTests.cs
@@ -67,7 +67,7 @@ namespace MeterReadingsApi.UnitTests
             // Arrange
             Mock<IMeterReadingUploadService> service = new Mock<IMeterReadingUploadService>();
             Mock<IMeterReadingsRepository> repo = new Mock<IMeterReadingsRepository>();
-            MeterReadingUploadResult uploadResult = new MeterReadingUploadResult(1, 0);
+            MeterReadingUploadResult uploadResult = new MeterReadingUploadResult(1, 0, Array.Empty<MeterReadingUploadFailure>());
             service.Setup(s => s.UploadAsync(It.IsAny<IFormFile>())).ReturnsAsync(uploadResult);
 
             Mock<IValidator<int>> validator = new Mock<IValidator<int>>();
@@ -89,7 +89,7 @@ namespace MeterReadingsApi.UnitTests
             // Arrange
             Mock<IMeterReadingUploadService> service = new Mock<IMeterReadingUploadService>();
             Mock<IMeterReadingsRepository> repo = new Mock<IMeterReadingsRepository>();
-            MeterReadingUploadResult uploadResult = new MeterReadingUploadResult(1, 1);
+            MeterReadingUploadResult uploadResult = new MeterReadingUploadResult(1, 1, new[] { new MeterReadingUploadFailure(2, "error") });
             service.Setup(s => s.UploadAsync(It.IsAny<IFormFile>())).ReturnsAsync(uploadResult);
 
             Mock<IValidator<int>> validator = new Mock<IValidator<int>>();
@@ -112,7 +112,7 @@ namespace MeterReadingsApi.UnitTests
             // Arrange
             Mock<IMeterReadingUploadService> service = new Mock<IMeterReadingUploadService>();
             Mock<IMeterReadingsRepository> repo = new Mock<IMeterReadingsRepository>();
-            MeterReadingUploadResult uploadResult = new MeterReadingUploadResult(0, 1);
+            MeterReadingUploadResult uploadResult = new MeterReadingUploadResult(0, 1, new[] { new MeterReadingUploadFailure(2, "error") });
             service.Setup(s => s.UploadAsync(It.IsAny<IFormFile>())).ReturnsAsync(uploadResult);
 
             Mock<IValidator<int>> validator = new Mock<IValidator<int>>();

--- a/MeterReadingsApi/MeterReadingsApi/Models/MeterReadingUploadFailure.cs
+++ b/MeterReadingsApi/MeterReadingsApi/Models/MeterReadingUploadFailure.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace MeterReadingsApi.Models;
+
+/// <summary>
+/// Represents a single failed meter reading upload including the row number and reason.
+/// </summary>
+[Serializable]
+public readonly record struct MeterReadingUploadFailure(
+    [property: JsonPropertyName("rowNumber")] int RowNumber,
+    [property: JsonPropertyName("reason")] string Reason);
+

--- a/MeterReadingsApi/MeterReadingsApi/Models/MeterReadingUploadResult.cs
+++ b/MeterReadingsApi/MeterReadingsApi/Models/MeterReadingUploadResult.cs
@@ -1,9 +1,14 @@
-﻿using System.Text.Json.Serialization;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
-namespace MeterReadingsApi.Models
-{
-    [Serializable]
-    public readonly record struct MeterReadingUploadResult(
-        [property: JsonPropertyName("successful")] int Successful,
-        [property: JsonPropertyName("failed")] int Failed);
-}
+namespace MeterReadingsApi.Models;
+
+/// <summary>
+/// Represents the outcome of a meter reading upload including counts and failure details.
+/// </summary>
+[Serializable]
+public readonly record struct MeterReadingUploadResult(
+    [property: JsonPropertyName("successful")] int Successful,
+    [property: JsonPropertyName("failed")] int Failed,
+    [property: JsonPropertyName("failures")] IReadOnlyList<MeterReadingUploadFailure> Failures);
+


### PR DESCRIPTION
## Summary
- extend upload result model with per-row failure details
- track and return row numbers and reasons when uploads fail
- cover new response structure with unit and integration tests

## Testing
- `dotnet test MeterReadingsApi/MeterReadingsApi.sln`

------
https://chatgpt.com/codex/tasks/task_e_688dea58f6a8833299354574a0aff966