### PR TITLE
Add unit test for missing headers

### DIFF
--- a/MeterReadingsApi/MeterReadingsApi.UnitTests/MeterReadingUploadRequestValidatorTests.cs
+++ b/MeterReadingsApi/MeterReadingsApi.UnitTests/MeterReadingUploadRequestValidatorTests.cs
@@ -37,5 +37,25 @@ namespace MeterReadingsApi.UnitTests
             Assert.False(result.IsValid);
             Assert.Contains(result.Errors, e => e.ErrorMessage.Contains("blank rows"));
         }
+
+        [Fact]
+        public void Validate_ReturnsError_When_HeaderRowIsBlank()
+        {
+            // Arrange
+            string csv = "\n" +
+                         "2344,16/05/2019 09:24,00123\n";
+            MeterReadingUploadRequest request = new MeterReadingUploadRequest
+            {
+                File = CreateFile(csv)
+            };
+            MeterReadingUploadRequestValidator validator = new MeterReadingUploadRequestValidator();
+
+            // Act
+            ValidationResult result = validator.Validate(request);
+
+            // Assert
+            Assert.False(result.IsValid);
+            Assert.Contains(result.Errors, e => e.ErrorMessage.Contains("Invalid or missing headers"));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add unit test verifying MeterReadingUploadRequestValidator fails when CSV header row is blank

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688e0fbbd110833294a613186d2b3b23