### PR TITLE
Add accounts endpoint

### DIFF
--- a/MeterReadingsApi/MeterReadingsApi.IntegrationTests/AccountsControllerIntegrationTests.cs
+++ b/MeterReadingsApi/MeterReadingsApi.IntegrationTests/AccountsControllerIntegrationTests.cs
@@ -1,0 +1,31 @@
+using MeterReadingsApi.DataModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
+using System.Text.Json;
+using Xunit;
+
+namespace MeterReadingsApi.IntegrationTests;
+
+[ExcludeFromCodeCoverage]
+public class AccountsControllerIntegrationTests : IClassFixture<TestApiFactory>
+{
+    private readonly HttpClient client;
+
+    public AccountsControllerIntegrationTests(TestApiFactory factory)
+    {
+        client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task Get_ReturnsAccounts()
+    {
+        // Act
+        HttpResponseMessage response = await client.GetAsync("/accounts");
+        response.EnsureSuccessStatusCode();
+        string body = await response.Content.ReadAsStringAsync();
+        List<Account> accounts = JsonSerializer.Deserialize<List<Account>>(body, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+
+        // Assert
+        Assert.NotEmpty(accounts);
+    }
+}

--- a/MeterReadingsApi/MeterReadingsApi.IntegrationTests/TestApiFactory.cs
+++ b/MeterReadingsApi/MeterReadingsApi.IntegrationTests/TestApiFactory.cs
@@ -5,12 +5,15 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using System.Diagnostics.CodeAnalysis;
+using System;
 
 namespace MeterReadingsApi.IntegrationTests;
 
 [ExcludeFromCodeCoverage]
 public class TestApiFactory : WebApplicationFactory<Program>
 {
+    private readonly string dbName = Guid.NewGuid().ToString();
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.ConfigureServices(services =>
@@ -22,7 +25,7 @@ public class TestApiFactory : WebApplicationFactory<Program>
             }
 
             services.AddDbContext<MeterReadingsContext>(options =>
-                options.UseInMemoryDatabase("TestDb"));
+                options.UseInMemoryDatabase(dbName));
 
             // Build provider to seed data
             ServiceProvider sp = services.BuildServiceProvider();

--- a/MeterReadingsApi/MeterReadingsApi.UnitTests/AccountsControllerTests.cs
+++ b/MeterReadingsApi/MeterReadingsApi.UnitTests/AccountsControllerTests.cs
@@ -1,0 +1,48 @@
+using MeterReadingsApi.Controllers;
+using MeterReadingsApi.DataModel;
+using MeterReadingsApi.Repositories;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+using System.Diagnostics.CodeAnalysis;
+
+namespace MeterReadingsApi.UnitTests
+{
+    [ExcludeFromCodeCoverage]
+    public class AccountsControllerTests
+    {
+        [Fact]
+        public void Get_Returns_Accounts()
+        {
+            // Arrange
+            Mock<IMeterReadingsRepository> repo = new Mock<IMeterReadingsRepository>();
+            Account account = new Account { AccountId = 1, FirstName = "A", LastName = "B" };
+            repo.Setup(r => r.GetAccounts()).Returns(new[] { account });
+            AccountsController controller = new AccountsController(repo.Object);
+
+            // Act
+            ActionResult result = controller.Get();
+
+            // Assert
+            OkObjectResult ok = Assert.IsType<OkObjectResult>(result);
+            IEnumerable<Account> accounts = Assert.IsAssignableFrom<IEnumerable<Account>>(ok.Value);
+            Assert.Single(accounts);
+            Assert.Equal(account, accounts.First());
+        }
+
+        [Fact]
+        public void Get_Returns_NoContent_When_No_Accounts()
+        {
+            // Arrange
+            Mock<IMeterReadingsRepository> repo = new Mock<IMeterReadingsRepository>();
+            repo.Setup(r => r.GetAccounts()).Returns(Array.Empty<Account>());
+            AccountsController controller = new AccountsController(repo.Object);
+
+            // Act
+            ActionResult result = controller.Get();
+
+            // Assert
+            Assert.IsType<NoContentResult>(result);
+        }
+    }
+}

--- a/MeterReadingsApi/MeterReadingsApi/Controllers/AccountsController.cs
+++ b/MeterReadingsApi/MeterReadingsApi/Controllers/AccountsController.cs
@@ -1,0 +1,31 @@
+using MeterReadingsApi.DataModel;
+using MeterReadingsApi.Repositories;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MeterReadingsApi.Controllers
+{
+    [Route("~/accounts")]
+    [ApiController]
+    public class AccountsController : ControllerBase
+    {
+        private readonly IMeterReadingsRepository repository;
+
+        public AccountsController(IMeterReadingsRepository repository)
+        {
+            this.repository = repository;
+        }
+
+        [HttpGet]
+        public ActionResult Get()
+        {
+            IEnumerable<Account> accounts = repository.GetAccounts();
+
+            if (!accounts.Any())
+            {
+                return NoContent();
+            }
+
+            return Ok(accounts);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add AccountsController with `~/accounts` route returning all accounts
- test controller with unit and integration tests
- isolate in-memory DB per test factory instance

## Testing
- `dotnet test MeterReadingsApi.sln`


------
https://chatgpt.com/codex/tasks/task_e_688e112a96e083329777b3d5ac9d51c5