### PR TITLE
Hide meter readings from account list

### DIFF
--- a/MeterReadingsApi/MeterReadingsApi.IntegrationTests/AccountsControllerIntegrationTests.cs
+++ b/MeterReadingsApi/MeterReadingsApi.IntegrationTests/AccountsControllerIntegrationTests.cs
@@ -1,4 +1,4 @@
-﻿using MeterReadingsApi.DataModel;
+using MeterReadingsApi.Models;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Xunit;
@@ -18,13 +18,26 @@ public class AccountsControllerIntegrationTests : IClassFixture<TestApiFactory>
     [Fact]
     public async Task Get_ReturnsAccounts()
     {
-        // Act
         HttpResponseMessage response = await client.GetAsync("/accounts");
         response.EnsureSuccessStatusCode();
         string body = await response.Content.ReadAsStringAsync();
-        List<Account> accounts = JsonSerializer.Deserialize<List<Account>>(body, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+        List<AccountDto> accounts = JsonSerializer.Deserialize<List<AccountDto>>(body, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
 
-        // Assert
         Assert.NotEmpty(accounts);
     }
+
+    [Fact]
+    public async Task Get_DoesNotReturnMeterReadings()
+    {
+        HttpResponseMessage response = await client.GetAsync("/accounts");
+        response.EnsureSuccessStatusCode();
+        string body = await response.Content.ReadAsStringAsync();
+
+        using JsonDocument doc = JsonDocument.Parse(body);
+        foreach (JsonElement account in doc.RootElement.EnumerateArray())
+        {
+            Assert.False(account.TryGetProperty("meterReadings", out _));
+        }
+    }
 }
+

--- a/MeterReadingsApi/MeterReadingsApi/Controllers/AccountsController.cs
+++ b/MeterReadingsApi/MeterReadingsApi/Controllers/AccountsController.cs
@@ -1,4 +1,6 @@
-﻿using MeterReadingsApi.DataModel;
+using AutoMapper;
+using MeterReadingsApi.DataModel;
+using MeterReadingsApi.Models;
 using MeterReadingsApi.Repositories;
 using Microsoft.AspNetCore.Mvc;
 
@@ -9,10 +11,12 @@ namespace MeterReadingsApi.Controllers
     public class AccountsController : ControllerBase
     {
         private readonly IMeterReadingsRepository repository;
+        private readonly IMapper mapper;
 
-        public AccountsController(IMeterReadingsRepository repository)
+        public AccountsController(IMeterReadingsRepository repository, IMapper mapper)
         {
             this.repository = repository;
+            this.mapper = mapper;
         }
 
         [HttpGet]
@@ -25,7 +29,9 @@ namespace MeterReadingsApi.Controllers
                 return NoContent();
             }
 
-            return Ok(accounts);
+            IEnumerable<AccountDto> result = mapper.Map<IEnumerable<AccountDto>>(accounts);
+            return Ok(result);
         }
     }
 }
+

--- a/MeterReadingsApi/MeterReadingsApi/MeterReadingsApi.csproj
+++ b/MeterReadingsApi/MeterReadingsApi/MeterReadingsApi.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.7" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.6.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.7" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MeterReadingsApi/MeterReadingsApi/Models/AccountDto.cs
+++ b/MeterReadingsApi/MeterReadingsApi/Models/AccountDto.cs
@@ -1,11 +1,10 @@
-namespace MeterReadingsApi.DataModel
+namespace MeterReadingsApi.Models
 {
-    public class Account
+    public class AccountDto
     {
         public int AccountId { get; set; }
         public string FirstName { get; set; } = string.Empty;
         public string LastName { get; set; } = string.Empty;
-        public List<MeterReading> MeterReadings { get; set; } = new();
     }
 }
 

--- a/MeterReadingsApi/MeterReadingsApi/Profiles/AccountProfile.cs
+++ b/MeterReadingsApi/MeterReadingsApi/Profiles/AccountProfile.cs
@@ -1,0 +1,15 @@
+using AutoMapper;
+using MeterReadingsApi.DataModel;
+using MeterReadingsApi.Models;
+
+namespace MeterReadingsApi.Profiles
+{
+    public class AccountProfile : Profile
+    {
+        public AccountProfile()
+        {
+            CreateMap<Account, AccountDto>();
+        }
+    }
+}
+

--- a/MeterReadingsApi/MeterReadingsApi/Program.cs
+++ b/MeterReadingsApi/MeterReadingsApi/Program.cs
@@ -1,4 +1,5 @@
-﻿using FluentValidation;
+using AutoMapper;
+using FluentValidation;
 using MeterReadingsApi.CsvMappers;
 using MeterReadingsApi.DataModel;
 using MeterReadingsApi.Interfaces;
@@ -20,6 +21,7 @@ namespace MeterReadingsApi
             // Services
             builder.Services.AddControllers();
             builder.Services.AddOpenApi();
+            builder.Services.AddAutoMapper(typeof(Program));
 
             string connectionString = builder.Configuration.GetConnectionString("DefaultConnection") ?? "Data Source=meterreadings.db";
             builder.Services.AddDbContext<MeterReadingsContext>(options => options.UseSqlite(connectionString));
@@ -54,3 +56,4 @@ namespace MeterReadingsApi
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- introduce AccountDto and AutoMapper profile to exclude meter readings from account responses
- map accounts to AccountDto in controller
- test accounts endpoint to ensure meterReadings field remains absent

## Testing
- `dotnet test MeterReadingsApi/MeterReadingsApi.sln`


------
https://chatgpt.com/codex/tasks/task_e_688e18378ab8833282c3b5a9e1e29c87