### PR TITLE
Use DTO for meter readings to omit account field

### DIFF
--- a/MeterReadingsApi/MeterReadingsApi.IntegrationTests/MeterReadingsControllerIntegrationTests.cs
+++ b/MeterReadingsApi/MeterReadingsApi.IntegrationTests/MeterReadingsControllerIntegrationTests.cs
@@ -1,5 +1,5 @@
-﻿using MeterReadingsApi.DataModel;
 using MeterReadingsApi.Models;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Http.Headers;
@@ -163,13 +163,14 @@ public class MeterReadingsControllerIntegrationTests : IClassFixture<TestApiFact
         HttpResponseMessage response = await client.GetAsync("/accounts/2344/meter-readings");
         response.EnsureSuccessStatusCode();
         string body = await response.Content.ReadAsStringAsync();
-        List<MeterReading> readings = JsonSerializer.Deserialize<List<MeterReading>>(body, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+        Assert.DoesNotContain("\"account\":", body, StringComparison.OrdinalIgnoreCase);
+        List<MeterReadingDto> readings = JsonSerializer.Deserialize<List<MeterReadingDto>>(body, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
 
         // Assert
         Assert.NotEmpty(readings);
-        MeterReading reading = readings.First();
+        MeterReadingDto reading = readings.First();
         Assert.Equal(2344, reading.AccountId);
-       Assert.Equal(123, reading.MeterReadValue);
+        Assert.Equal(123, reading.MeterReadValue);
     }
 
     [Fact]
@@ -192,3 +193,4 @@ public class MeterReadingsControllerIntegrationTests : IClassFixture<TestApiFact
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 }
+

--- a/MeterReadingsApi/MeterReadingsApi.UnitTests/MeterReadingsControllerTests.cs
+++ b/MeterReadingsApi/MeterReadingsApi.UnitTests/MeterReadingsControllerTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentValidation;
+using AutoMapper;
+using FluentValidation;
 using FluentValidation.Results;
 using MeterReadingsApi.Controllers;
 using MeterReadingsApi.DataModel;
@@ -31,7 +32,8 @@ namespace MeterReadingsApi.UnitTests
             Mock<IValidator<MeterReadingUploadRequest>> fileValidator = new Mock<IValidator<MeterReadingUploadRequest>>();
             fileValidator.Setup(v => v.Validate(It.IsAny<MeterReadingUploadRequest>()))
                 .Returns(new ValidationResult(new[] { new ValidationFailure("File", "File contains blank rows") }));
-            MeterReadingsController controller = new MeterReadingsController(service.Object, repo.Object, validator.Object, fileValidator.Object);
+            IMapper mapper = new MapperConfiguration(cfg => cfg.CreateMap<MeterReading, MeterReadingDto>()).CreateMapper();
+            MeterReadingsController controller = new MeterReadingsController(service.Object, repo.Object, validator.Object, fileValidator.Object, mapper);
 
             // Act
             ActionResult result = await controller.MeterReadingUploads(new MeterReadingUploadRequest());
@@ -55,7 +57,8 @@ namespace MeterReadingsApi.UnitTests
             Mock<IValidator<int>> validator = new Mock<IValidator<int>>();
             Mock<IValidator<MeterReadingUploadRequest>> fileValidator = new Mock<IValidator<MeterReadingUploadRequest>>();
             fileValidator.Setup(v => v.Validate(It.IsAny<MeterReadingUploadRequest>())).Returns(new ValidationResult());
-            MeterReadingsController controller = new MeterReadingsController(service.Object, repo.Object, validator.Object, fileValidator.Object);
+            IMapper mapper = new MapperConfiguration(cfg => cfg.CreateMap<MeterReading, MeterReadingDto>()).CreateMapper();
+            MeterReadingsController controller = new MeterReadingsController(service.Object, repo.Object, validator.Object, fileValidator.Object, mapper);
             IFormFile file = CreateFile();
 
             // Act
@@ -66,7 +69,6 @@ namespace MeterReadingsApi.UnitTests
             Assert.Equal(uploadResult, created.Value);
             service.Verify(s => s.UploadAsync(It.IsAny<IFormFile>()), Times.Once);
         }
-
 
         [Fact]
         public async Task MeterReadingUploads_Returns_MultiStatus_When_Some_Fail()
@@ -80,7 +82,8 @@ namespace MeterReadingsApi.UnitTests
             Mock<IValidator<int>> validator = new Mock<IValidator<int>>();
             Mock<IValidator<MeterReadingUploadRequest>> fileValidator = new Mock<IValidator<MeterReadingUploadRequest>>();
             fileValidator.Setup(v => v.Validate(It.IsAny<MeterReadingUploadRequest>())).Returns(new ValidationResult());
-            MeterReadingsController controller = new MeterReadingsController(service.Object, repo.Object, validator.Object, fileValidator.Object);
+            IMapper mapper = new MapperConfiguration(cfg => cfg.CreateMap<MeterReading, MeterReadingDto>()).CreateMapper();
+            MeterReadingsController controller = new MeterReadingsController(service.Object, repo.Object, validator.Object, fileValidator.Object, mapper);
             IFormFile file = CreateFile();
 
             // Act
@@ -105,7 +108,8 @@ namespace MeterReadingsApi.UnitTests
             Mock<IValidator<int>> validator = new Mock<IValidator<int>>();
             Mock<IValidator<MeterReadingUploadRequest>> fileValidator = new Mock<IValidator<MeterReadingUploadRequest>>();
             fileValidator.Setup(v => v.Validate(It.IsAny<MeterReadingUploadRequest>())).Returns(new ValidationResult());
-            MeterReadingsController controller = new MeterReadingsController(service.Object, repo.Object, validator.Object, fileValidator.Object);
+            IMapper mapper = new MapperConfiguration(cfg => cfg.CreateMap<MeterReading, MeterReadingDto>()).CreateMapper();
+            MeterReadingsController controller = new MeterReadingsController(service.Object, repo.Object, validator.Object, fileValidator.Object, mapper);
             IFormFile file = CreateFile();
 
             // Act
@@ -128,16 +132,19 @@ namespace MeterReadingsApi.UnitTests
             Mock<IValidator<int>> validator = new Mock<IValidator<int>>();
             validator.Setup(v => v.Validate(1)).Returns(new ValidationResult());
             Mock<IValidator<MeterReadingUploadRequest>> fileValidator = new Mock<IValidator<MeterReadingUploadRequest>>();
-            MeterReadingsController controller = new MeterReadingsController(service.Object, repo.Object, validator.Object, fileValidator.Object);
+            IMapper mapper = new MapperConfiguration(cfg => cfg.CreateMap<MeterReading, MeterReadingDto>()).CreateMapper();
+            MeterReadingsController controller = new MeterReadingsController(service.Object, repo.Object, validator.Object, fileValidator.Object, mapper);
 
             // Act
             ActionResult result = controller.GetByAccountId(1);
 
             // Assert
             OkObjectResult ok = Assert.IsType<OkObjectResult>(result);
-            IEnumerable<MeterReading> readings = Assert.IsAssignableFrom<IEnumerable<MeterReading>>(ok.Value);
-            Assert.Single(readings);
-            Assert.Equal(reading, readings.First());
+            IEnumerable<MeterReadingDto> readings = Assert.IsAssignableFrom<IEnumerable<MeterReadingDto>>(ok.Value);
+            MeterReadingDto dto = Assert.Single(readings);
+            Assert.Equal(reading.AccountId, dto.AccountId);
+            Assert.Equal(reading.MeterReadingDateTime, dto.MeterReadingDateTime);
+            Assert.Equal(reading.MeterReadValue, dto.MeterReadValue);
         }
 
         [Fact]
@@ -150,7 +157,8 @@ namespace MeterReadingsApi.UnitTests
             Mock<IValidator<int>> validator = new Mock<IValidator<int>>();
             validator.Setup(v => v.Validate(1)).Returns(new ValidationResult());
             Mock<IValidator<MeterReadingUploadRequest>> fileValidator = new Mock<IValidator<MeterReadingUploadRequest>>();
-            MeterReadingsController controller = new MeterReadingsController(service.Object, repo.Object, validator.Object, fileValidator.Object);
+            IMapper mapper = new MapperConfiguration(cfg => cfg.CreateMap<MeterReading, MeterReadingDto>()).CreateMapper();
+            MeterReadingsController controller = new MeterReadingsController(service.Object, repo.Object, validator.Object, fileValidator.Object, mapper);
 
             // Act
             ActionResult result = controller.GetByAccountId(1);
@@ -168,7 +176,8 @@ namespace MeterReadingsApi.UnitTests
             Mock<IValidator<int>> validator = new Mock<IValidator<int>>();
             validator.Setup(v => v.Validate(1)).Returns(new ValidationResult(new[] { new ValidationFailure("AccountId", "error") }));
             Mock<IValidator<MeterReadingUploadRequest>> fileValidator = new Mock<IValidator<MeterReadingUploadRequest>>();
-            MeterReadingsController controller = new MeterReadingsController(service.Object, repo.Object, validator.Object, fileValidator.Object);
+            IMapper mapper = new MapperConfiguration(cfg => cfg.CreateMap<MeterReading, MeterReadingDto>()).CreateMapper();
+            MeterReadingsController controller = new MeterReadingsController(service.Object, repo.Object, validator.Object, fileValidator.Object, mapper);
 
             // Act
             ActionResult result = controller.GetByAccountId(1);
@@ -178,3 +187,4 @@ namespace MeterReadingsApi.UnitTests
         }
     }
 }
+

--- a/MeterReadingsApi/MeterReadingsApi/Controllers/MeterReadingsController.cs
+++ b/MeterReadingsApi/MeterReadingsApi/Controllers/MeterReadingsController.cs
@@ -1,4 +1,5 @@
-﻿using FluentValidation;
+using AutoMapper;
+using FluentValidation;
 using FluentValidation.Results;
 using MeterReadingsApi.DataModel;
 using MeterReadingsApi.Interfaces;
@@ -15,13 +16,20 @@ namespace MeterReadingsApi.Controllers
         private readonly IMeterReadingsRepository repository;
         private readonly IValidator<int> accountIdValidator;
         private readonly IValidator<MeterReadingUploadRequest> fileValidator;
+        private readonly IMapper mapper;
 
-        public MeterReadingsController(IMeterReadingUploadService uploadService, IMeterReadingsRepository repository, IValidator<int> accountIdValidator, IValidator<MeterReadingUploadRequest> fileValidator)
+        public MeterReadingsController(
+            IMeterReadingUploadService uploadService,
+            IMeterReadingsRepository repository,
+            IValidator<int> accountIdValidator,
+            IValidator<MeterReadingUploadRequest> fileValidator,
+            IMapper mapper)
         {
             this.uploadService = uploadService;
             this.repository = repository;
             this.accountIdValidator = accountIdValidator;
             this.fileValidator = fileValidator;
+            this.mapper = mapper;
         }
 
         [Route("~/accounts/{accountId}/meter-readings")]
@@ -41,7 +49,8 @@ namespace MeterReadingsApi.Controllers
                 return NoContent();
             }
 
-            return Ok(readings);
+            IEnumerable<MeterReadingDto> result = mapper.Map<IEnumerable<MeterReadingDto>>(readings);
+            return Ok(result);
         }
 
         [Route("~/meter-reading-uploads")]
@@ -63,3 +72,4 @@ namespace MeterReadingsApi.Controllers
         }
     }
 }
+

--- a/MeterReadingsApi/MeterReadingsApi/Mappers/MeterReadingMapper.cs
+++ b/MeterReadingsApi/MeterReadingsApi/Mappers/MeterReadingMapper.cs
@@ -1,0 +1,15 @@
+using AutoMapper;
+using MeterReadingsApi.DataModel;
+using MeterReadingsApi.Models;
+
+namespace MeterReadingsApi.Mappers
+{
+    public class MeterReadingMapper : Profile
+    {
+        public MeterReadingMapper()
+        {
+            CreateMap<MeterReading, MeterReadingDto>();
+        }
+    }
+}
+

--- a/MeterReadingsApi/MeterReadingsApi/Models/MeterReadingDto.cs
+++ b/MeterReadingsApi/MeterReadingsApi/Models/MeterReadingDto.cs
@@ -1,0 +1,10 @@
+namespace MeterReadingsApi.Models
+{
+    public class MeterReadingDto
+    {
+        public int AccountId { get; set; }
+        public DateTime MeterReadingDateTime { get; set; }
+        public int MeterReadValue { get; set; }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `MeterReadingDto` and AutoMapper profile
- map meter readings to the DTO in controller to hide `Account` property
- update unit and integration tests for the new response

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688e1d8ce348833292bbac51d38d182f