### PR TITLE
Handle empty meter readings in Blazor client

### DIFF
--- a/MeterReadingsApi/MeterReadingsBlazorClient/Pages/Home.razor
+++ b/MeterReadingsApi/MeterReadingsBlazorClient/Pages/Home.razor
@@ -40,6 +40,15 @@
 
     private async Task OnAccountSelected(AccountDto account)
     {
-        meterReadings = await Http.GetFromJsonAsync<IList<MeterReadingDto>>($"accounts/{account.AccountId}/meter-readings");
+        var response = await Http.GetAsync($"accounts/{account.AccountId}/meter-readings");
+        if (response.StatusCode == System.Net.HttpStatusCode.NoContent)
+        {
+            meterReadings = Array.Empty<MeterReadingDto>();
+        }
+        else
+        {
+            response.EnsureSuccessStatusCode();
+            meterReadings = await response.Content.ReadFromJsonAsync<IList<MeterReadingDto>>();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Handle 204 No Content responses when fetching meter readings to avoid JSON parsing errors

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688e2efd7eac8332a9ca0b0a6da59aeb