### PR TITLE
refactor: share DTOs between API and client

### DIFF
--- a/MeterReadingsApi/MeterReadingsApi.IntegrationTests/AccountsControllerIntegrationTests.cs
+++ b/MeterReadingsApi/MeterReadingsApi.IntegrationTests/AccountsControllerIntegrationTests.cs
@@ -1,4 +1,4 @@
-﻿using MeterReadingsApi.Models;
+﻿using MeterReadingsApi.Shared;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Xunit;

--- a/MeterReadingsApi/MeterReadingsApi.IntegrationTests/MeterReadingsApi.IntegrationTests.csproj
+++ b/MeterReadingsApi/MeterReadingsApi.IntegrationTests/MeterReadingsApi.IntegrationTests.csproj
@@ -22,5 +22,6 @@
   <ItemGroup>
     <ProjectReference Include="..\MeterReadingsApi\MeterReadingsApi.csproj" />
     <ProjectReference Include="..\MeterReadingsApi.DataModel\MeterReadingsApi.DataModel.csproj" />
+    <ProjectReference Include="..\MeterReadingsApi.Shared\MeterReadingsApi.Shared.csproj" />
   </ItemGroup>
 </Project>

--- a/MeterReadingsApi/MeterReadingsApi.IntegrationTests/MeterReadingsControllerIntegrationTests.cs
+++ b/MeterReadingsApi/MeterReadingsApi.IntegrationTests/MeterReadingsControllerIntegrationTests.cs
@@ -1,4 +1,5 @@
-﻿using MeterReadingsApi.Models;
+using MeterReadingsApi.Models;
+using MeterReadingsApi.Shared;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Http.Headers;

--- a/MeterReadingsApi/MeterReadingsApi.Shared/AccountDto.cs
+++ b/MeterReadingsApi/MeterReadingsApi.Shared/AccountDto.cs
@@ -1,0 +1,8 @@
+namespace MeterReadingsApi.Shared;
+
+public class AccountDto
+{
+    public int AccountId { get; set; }
+    public string FirstName { get; set; } = string.Empty;
+    public string LastName { get; set; } = string.Empty;
+}

--- a/MeterReadingsApi/MeterReadingsApi.Shared/MeterReadingDto.cs
+++ b/MeterReadingsApi/MeterReadingsApi.Shared/MeterReadingDto.cs
@@ -1,0 +1,8 @@
+namespace MeterReadingsApi.Shared;
+
+public class MeterReadingDto
+{
+    public int AccountId { get; set; }
+    public DateTime MeterReadingDateTime { get; set; }
+    public int MeterReadValue { get; set; }
+}

--- a/MeterReadingsApi/MeterReadingsApi.Shared/MeterReadingsApi.Shared.csproj
+++ b/MeterReadingsApi/MeterReadingsApi.Shared/MeterReadingsApi.Shared.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/MeterReadingsApi/MeterReadingsApi.UnitTests/AccountsControllerTests.cs
+++ b/MeterReadingsApi/MeterReadingsApi.UnitTests/AccountsControllerTests.cs
@@ -1,7 +1,7 @@
 ﻿using AutoMapper;
 using MeterReadingsApi.Controllers;
 using MeterReadingsApi.DataModel;
-using MeterReadingsApi.Models;
+using MeterReadingsApi.Shared;
 using MeterReadingsApi.Repositories;
 using Microsoft.AspNetCore.Mvc;
 using Moq;

--- a/MeterReadingsApi/MeterReadingsApi.UnitTests/MeterReadingsApi.UnitTests.csproj
+++ b/MeterReadingsApi/MeterReadingsApi.UnitTests/MeterReadingsApi.UnitTests.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\MeterReadingsApi\MeterReadingsApi.csproj" />
+    <ProjectReference Include="..\MeterReadingsApi.Shared\MeterReadingsApi.Shared.csproj" />
   </ItemGroup>
 
 </Project>

--- a/MeterReadingsApi/MeterReadingsApi.UnitTests/MeterReadingsControllerTests.cs
+++ b/MeterReadingsApi/MeterReadingsApi.UnitTests/MeterReadingsControllerTests.cs
@@ -5,6 +5,7 @@ using MeterReadingsApi.Controllers;
 using MeterReadingsApi.DataModel;
 using MeterReadingsApi.Interfaces;
 using MeterReadingsApi.Models;
+using MeterReadingsApi.Shared;
 using MeterReadingsApi.Repositories;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;

--- a/MeterReadingsApi/MeterReadingsApi.sln
+++ b/MeterReadingsApi/MeterReadingsApi.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MeterReadingsApi.Integratio
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MeterReadingsBlazorClient", "MeterReadingsBlazorClient\MeterReadingsBlazorClient.csproj", "{BD58CEFD-DEF8-4F48-90DC-D0B7EAFC2B9E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MeterReadingsApi.Shared", "MeterReadingsApi.Shared\MeterReadingsApi.Shared.csproj", "{B75C1C24-B465-4F5F-B631-26F5D31DFD42}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -83,6 +85,18 @@ Global
 		{BD58CEFD-DEF8-4F48-90DC-D0B7EAFC2B9E}.Release|x64.Build.0 = Release|Any CPU
 		{BD58CEFD-DEF8-4F48-90DC-D0B7EAFC2B9E}.Release|x86.ActiveCfg = Release|Any CPU
 		{BD58CEFD-DEF8-4F48-90DC-D0B7EAFC2B9E}.Release|x86.Build.0 = Release|Any CPU
+		{B75C1C24-B465-4F5F-B631-26F5D31DFD42}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B75C1C24-B465-4F5F-B631-26F5D31DFD42}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B75C1C24-B465-4F5F-B631-26F5D31DFD42}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B75C1C24-B465-4F5F-B631-26F5D31DFD42}.Debug|x64.Build.0 = Debug|Any CPU
+		{B75C1C24-B465-4F5F-B631-26F5D31DFD42}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B75C1C24-B465-4F5F-B631-26F5D31DFD42}.Debug|x86.Build.0 = Debug|Any CPU
+		{B75C1C24-B465-4F5F-B631-26F5D31DFD42}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B75C1C24-B465-4F5F-B631-26F5D31DFD42}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B75C1C24-B465-4F5F-B631-26F5D31DFD42}.Release|x64.ActiveCfg = Release|Any CPU
+		{B75C1C24-B465-4F5F-B631-26F5D31DFD42}.Release|x64.Build.0 = Release|Any CPU
+		{B75C1C24-B465-4F5F-B631-26F5D31DFD42}.Release|x86.ActiveCfg = Release|Any CPU
+		{B75C1C24-B465-4F5F-B631-26F5D31DFD42}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MeterReadingsApi/MeterReadingsApi/Controllers/AccountsController.cs
+++ b/MeterReadingsApi/MeterReadingsApi/Controllers/AccountsController.cs
@@ -1,6 +1,6 @@
 ﻿using AutoMapper;
 using MeterReadingsApi.DataModel;
-using MeterReadingsApi.Models;
+using MeterReadingsApi.Shared;
 using MeterReadingsApi.Repositories;
 using Microsoft.AspNetCore.Mvc;
 

--- a/MeterReadingsApi/MeterReadingsApi/Controllers/MeterReadingsController.cs
+++ b/MeterReadingsApi/MeterReadingsApi/Controllers/MeterReadingsController.cs
@@ -4,6 +4,7 @@ using FluentValidation.Results;
 using MeterReadingsApi.DataModel;
 using MeterReadingsApi.Interfaces;
 using MeterReadingsApi.Models;
+using MeterReadingsApi.Shared;
 using MeterReadingsApi.Repositories;
 using Microsoft.AspNetCore.Mvc;
 

--- a/MeterReadingsApi/MeterReadingsApi/Mappers/AccountMapper.cs
+++ b/MeterReadingsApi/MeterReadingsApi/Mappers/AccountMapper.cs
@@ -1,6 +1,6 @@
 ﻿using AutoMapper;
 using MeterReadingsApi.DataModel;
-using MeterReadingsApi.Models;
+using MeterReadingsApi.Shared;
 
 namespace MeterReadingsApi.Mappers
 {

--- a/MeterReadingsApi/MeterReadingsApi/Mappers/MeterReadingMapper.cs
+++ b/MeterReadingsApi/MeterReadingsApi/Mappers/MeterReadingMapper.cs
@@ -1,6 +1,6 @@
 ﻿using AutoMapper;
 using MeterReadingsApi.DataModel;
-using MeterReadingsApi.Models;
+using MeterReadingsApi.Shared;
 
 namespace MeterReadingsApi.Mappers
 {

--- a/MeterReadingsApi/MeterReadingsApi/MeterReadingsApi.csproj
+++ b/MeterReadingsApi/MeterReadingsApi/MeterReadingsApi.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\MeterReadingsApi.DataModel\MeterReadingsApi.DataModel.csproj" />
+    <ProjectReference Include="..\MeterReadingsApi.Shared\MeterReadingsApi.Shared.csproj" />
   </ItemGroup>
 
 </Project>

--- a/MeterReadingsApi/MeterReadingsApi/Models/AccountDto.cs
+++ b/MeterReadingsApi/MeterReadingsApi/Models/AccountDto.cs
@@ -1,9 +1,0 @@
-﻿namespace MeterReadingsApi.Models
-{
-    public class AccountDto
-    {
-        public int AccountId { get; set; }
-        public string FirstName { get; set; } = string.Empty;
-        public string LastName { get; set; } = string.Empty;
-    }
-}

--- a/MeterReadingsApi/MeterReadingsApi/Models/MeterReadingDto.cs
+++ b/MeterReadingsApi/MeterReadingsApi/Models/MeterReadingDto.cs
@@ -1,9 +1,0 @@
-﻿namespace MeterReadingsApi.Models
-{
-    public class MeterReadingDto
-    {
-        public int AccountId { get; set; }
-        public DateTime MeterReadingDateTime { get; set; }
-        public int MeterReadValue { get; set; }
-    }
-}

--- a/MeterReadingsApi/MeterReadingsBlazorClient/MeterReadingsBlazorClient.csproj
+++ b/MeterReadingsApi/MeterReadingsBlazorClient/MeterReadingsBlazorClient.csproj
@@ -15,4 +15,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.7" PrivateAssets="all" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\MeterReadingsApi.Shared\MeterReadingsApi.Shared.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/MeterReadingsApi/MeterReadingsBlazorClient/Models/AccountDto.cs
+++ b/MeterReadingsApi/MeterReadingsBlazorClient/Models/AccountDto.cs
@@ -1,9 +1,0 @@
-namespace MeterReadingsBlazorClient.Models
-{
-    public class AccountDto
-    {
-        public int AccountId { get; set; }
-        public string FirstName { get; set; } = string.Empty;
-        public string LastName { get; set; } = string.Empty;
-    }
-}

--- a/MeterReadingsApi/MeterReadingsBlazorClient/Models/MeterReadingDto.cs
+++ b/MeterReadingsApi/MeterReadingsBlazorClient/Models/MeterReadingDto.cs
@@ -1,9 +1,0 @@
-namespace MeterReadingsBlazorClient.Models
-{
-    public class MeterReadingDto
-    {
-        public int AccountId { get; set; }
-        public DateTime MeterReadingDateTime { get; set; }
-        public int MeterReadValue { get; set; }
-    }
-}

--- a/MeterReadingsApi/MeterReadingsBlazorClient/Pages/Home.razor.cs
+++ b/MeterReadingsApi/MeterReadingsBlazorClient/Pages/Home.razor.cs
@@ -1,4 +1,4 @@
-﻿using MeterReadingsBlazorClient.Models;
+using MeterReadingsApi.Shared;
 using System.Net.Http.Json;
 
 namespace MeterReadingsBlazorClient.Pages

--- a/MeterReadingsApi/MeterReadingsBlazorClient/_Imports.razor
+++ b/MeterReadingsApi/MeterReadingsBlazorClient/_Imports.razor
@@ -8,6 +8,6 @@
 @using Microsoft.JSInterop
 @using MeterReadingsBlazorClient
 @using MeterReadingsBlazorClient.Layout
-@using MeterReadingsBlazorClient.Models
+@using MeterReadingsApi.Shared
 @using Blazorise
 @using Blazorise.DataGrid


### PR DESCRIPTION
## Summary
- centralize AccountDto and MeterReadingDto in new MeterReadingsApi.Shared project
- reference shared project from API and Blazor client
- update controllers, mappers, tests, and UI to use shared DTOs

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688e31e4c61083328a63218488e85b5b