### PR TITLE
refactor: use explicit types in bunit tests

### DIFF
--- a/MeterReadingsApi/MeterReadingsBlazorClient.BUnit/HomeTests.cs
+++ b/MeterReadingsApi/MeterReadingsBlazorClient.BUnit/HomeTests.cs
@@ -3,17 +3,19 @@ using MeterReadingsBlazorClient.Pages;
 using Microsoft.Extensions.DependencyInjection;
 using System.Net;
 using System.Net.Http.Json;
+using System.Reflection;
 
 public partial class HomeTests : BlazoriseTestBase
 {
     [Fact]
     public void Home_LoadsAccountsOnInit()
     {
-        var handler = new TestHttpMessageHandler(req =>
+        // Arrange
+        TestHttpMessageHandler handler = new(req =>
         {
             if (req.RequestUri?.AbsolutePath == "/accounts")
             {
-                var accounts = new[] { new AccountDto { AccountId = 1, FirstName = "Jane", LastName = "Doe" } };
+                AccountDto[] accounts = new[] { new AccountDto { AccountId = 1, FirstName = "Jane", LastName = "Doe" } };
                 return new HttpResponseMessage(HttpStatusCode.OK)
                 {
                     Content = JsonContent.Create(accounts)
@@ -21,13 +23,15 @@ public partial class HomeTests : BlazoriseTestBase
             }
             return new HttpResponseMessage(HttpStatusCode.NotFound);
         });
-        var client = new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
+        HttpClient client = new(handler) { BaseAddress = new Uri("http://localhost") };
         Services.AddSingleton(client);
 
-        var cut = RenderComponent<Home>();
+        // Act
+        IRenderedComponent<Home> cut = RenderComponent<Home>();
 
-        var accountsField = typeof(Home).GetField("accounts", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        var accounts = accountsField?.GetValue(cut.Instance) as IList<AccountDto>;
+        // Assert
+        FieldInfo? accountsField = typeof(Home).GetField("accounts", BindingFlags.NonPublic | BindingFlags.Instance);
+        IList<AccountDto>? accounts = accountsField?.GetValue(cut.Instance) as IList<AccountDto>;
         Assert.NotNull(accounts);
         Assert.Single(accounts!);
         Assert.Equal("Jane", accounts![0].FirstName);
@@ -36,11 +40,12 @@ public partial class HomeTests : BlazoriseTestBase
     [Fact]
     public async Task Home_LoadsMeterReadingsWhenAccountSelected()
     {
-        var handler = new TestHttpMessageHandler(req =>
+        // Arrange
+        TestHttpMessageHandler handler = new(req =>
         {
             if (req.RequestUri?.AbsolutePath == "/accounts")
             {
-                var accounts = new[] { new AccountDto { AccountId = 1, FirstName = "Jane", LastName = "Doe" } };
+                AccountDto[] accounts = new[] { new AccountDto { AccountId = 1, FirstName = "Jane", LastName = "Doe" } };
                 return new HttpResponseMessage(HttpStatusCode.OK)
                 {
                     Content = JsonContent.Create(accounts)
@@ -48,7 +53,7 @@ public partial class HomeTests : BlazoriseTestBase
             }
             if (req.RequestUri?.AbsolutePath == "/accounts/1/meter-readings")
             {
-                var readings = new[]
+                MeterReadingDto[] readings =
                 {
                     new MeterReadingDto { AccountId = 1, MeterReadingDateTime = new DateTime(2024,1,2,3,4,5), MeterReadValue = 12345 }
                 };
@@ -59,16 +64,18 @@ public partial class HomeTests : BlazoriseTestBase
             }
             return new HttpResponseMessage(HttpStatusCode.NotFound);
         });
-        var client = new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
+        HttpClient client = new(handler) { BaseAddress = new Uri("http://localhost") };
         Services.AddSingleton(client);
+        IRenderedComponent<Home> cut = RenderComponent<Home>();
+        AccountDto account = new() { AccountId = 1, FirstName = "Jane", LastName = "Doe" };
+        MethodInfo method = typeof(Home).GetMethod("OnAccountSelected", BindingFlags.Instance | BindingFlags.NonPublic)!;
 
-        var cut = RenderComponent<Home>();
-        var account = new AccountDto { AccountId = 1, FirstName = "Jane", LastName = "Doe" };
-        var method = typeof(Home).GetMethod("OnAccountSelected", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        // Act
         await cut.InvokeAsync(() => (Task)method.Invoke(cut.Instance, new object[] { account })!);
 
-        var meterReadingsField = typeof(Home).GetField("meterReadings", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        var readings = meterReadingsField?.GetValue(cut.Instance) as IList<MeterReadingDto>;
+        // Assert
+        FieldInfo? meterReadingsField = typeof(Home).GetField("meterReadings", BindingFlags.NonPublic | BindingFlags.Instance);
+        IList<MeterReadingDto>? readings = meterReadingsField?.GetValue(cut.Instance) as IList<MeterReadingDto>;
         Assert.NotNull(readings);
         Assert.Single(readings!);
         Assert.Equal(12345, readings![0].MeterReadValue);


### PR DESCRIPTION
## Summary
- use explicit types in Blazor client bUnit tests
- add Arrange/Act/Assert comments for clarity

## Testing
- `dotnet test MeterReadingsApi/MeterReadingsApi.sln`


------
https://chatgpt.com/codex/tasks/task_e_688e424f70b083329e4edbfb85b1edb8