### PR TITLE
Use row click to load meter readings

### DIFF
--- a/MeterReadingsApi/MeterReadingsBlazorClient.BUnit/HomeTests.cs
+++ b/MeterReadingsApi/MeterReadingsBlazorClient.BUnit/HomeTests.cs
@@ -1,4 +1,5 @@
-﻿using MeterReadingsApi.Shared;
+﻿using Bunit;
+using MeterReadingsApi.Shared;
 using MeterReadingsBlazorClient.Pages;
 using Microsoft.Extensions.DependencyInjection;
 using System.Net;
@@ -69,17 +70,18 @@ public partial class HomeTests : BlazoriseTestBase
         HttpClient client = new(handler) { BaseAddress = new Uri("http://localhost") };
         Services.AddSingleton(client);
         IRenderedComponent<Home> cut = RenderComponent<Home>();
-        AccountDto account = new() { AccountId = 1, FirstName = "Jane", LastName = "Doe" };
-        MethodInfo method = typeof(Home).GetMethod("OnAccountSelected", BindingFlags.Instance | BindingFlags.NonPublic)!;
 
         // Act
-        await cut.InvokeAsync(() => (Task)method.Invoke(cut.Instance, new object[] { account })!);
+        await cut.InvokeAsync(() => cut.Find("tbody tr").Click());
 
         // Assert
         FieldInfo? meterReadingsField = typeof(Home).GetField("meterReadings", BindingFlags.NonPublic | BindingFlags.Instance);
-        IList<MeterReadingDto>? readings = meterReadingsField?.GetValue(cut.Instance) as IList<MeterReadingDto>;
-        Assert.NotNull(readings);
-        Assert.Single(readings!);
-        Assert.Equal(12345, readings![0].MeterReadValue);
+        cut.WaitForAssertion(() =>
+        {
+            IList<MeterReadingDto>? readings = meterReadingsField?.GetValue(cut.Instance) as IList<MeterReadingDto>;
+            Assert.NotNull(readings);
+            Assert.Single(readings!);
+            Assert.Equal(12345, readings![0].MeterReadValue);
+        });
     }
 }


### PR DESCRIPTION
## Summary
- Simulate a user clicking an account row instead of invoking `OnAccountSelected` via reflection in the `Home_LoadsMeterReadingsWhenAccountSelected` test
- Wait for state changes and assert retrieved meter readings after the click

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688e5035c2e083329580126b39194de6