### PR TITLE
Make API base URL configurable in Blazor client

### DIFF
--- a/MeterReadingsApi/MeterReadingsBlazorClient/Program.cs
+++ b/MeterReadingsApi/MeterReadingsBlazorClient/Program.cs
@@ -9,7 +9,8 @@ var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
-builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri("https://localhost:7242/") });
+var apiBaseUrl = builder.Configuration["MeterReadingsApiBaseUrl"] ?? "https://localhost:7242/";
+builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(apiBaseUrl) });
 
 builder.Services
     .AddBlazorise(options =>

--- a/MeterReadingsApi/MeterReadingsBlazorClient/wwwroot/appsettings.json
+++ b/MeterReadingsApi/MeterReadingsBlazorClient/wwwroot/appsettings.json
@@ -1,0 +1,3 @@
+{
+  "MeterReadingsApiBaseUrl": "https://localhost:7242/"
+}


### PR DESCRIPTION
## Summary
- allow Blazor client to read API URL from configuration
- add default MeterReadings API base URL to appsettings.json

## Testing
- `dotnet test MeterReadingsApi/MeterReadingsApi.sln`


------
https://chatgpt.com/codex/tasks/task_e_688e57102fb08332b6a2e63b4ef66766